### PR TITLE
Make getShow output more conformant

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -127,7 +127,7 @@ const showWeather = getShow<Weather>({
 })
 
 assert.strictEqual(showWeather.show(Sun), 'Sun')
-assert.strictEqual(showWeather.show(Rain(1)), 'Rain 1')
+assert.strictEqual(showWeather.show(Rain(1)), 'Rain(1)')
 ```
 
 Added in v0.1.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,7 +156,7 @@ export const getOrd = <A extends Sum.AnyMember>(ords: Ords<A>): Ord<A> =>
  * })
  *
  * assert.strictEqual(showWeather.show(Sun), 'Sun')
- * assert.strictEqual(showWeather.show(Rain(1)), 'Rain 1')
+ * assert.strictEqual(showWeather.show(Rain(1)), 'Rain(1)')
  *
  * @since 0.1.0
  */
@@ -172,9 +172,9 @@ export const getShow = <A extends Sum.AnyMember>(shows: Shows<A>): Show<A> => ({
     //      defined a member for which the value actually can tangibly be `null`
     //      e.g. `Member<'Rain', number | null>`.
     return k in shows
-      ? `${k} ${(shows[k as keyof typeof shows] as unknown as Show<Value<A>>)
+      ? `${k}(${(shows[k as keyof typeof shows] as unknown as Show<Value<A>>)
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .show(v as any)}`
+          .show(v as any)})`
       : k
   },
 })

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -103,8 +103,8 @@ describe("index", () => {
     })
 
     it("outputs members with values using provived Show instance", () => {
-      expect(f(A(42))).toBe("A 42")
-      expect(f(C(42))).toBe("C 24")
+      expect(f(A(42))).toBe("A(42)")
+      expect(f(C(42))).toBe("C(24)")
     })
   })
 })


### PR DESCRIPTION
Like this we better adhere to the idea that `Show`'s output should ideally be a valid TypeScript expression that'd be reversible with something equivalent to Haskell's `Read`. This therefore also makes the output equivalent to that of fp-ts' sums such as `Either`.


```ts
type Sum = Member<"A"> | Member<"B", number>
```

```diff
show(Sum.mk.A) === "A"
-show(Sum.mk.B(123)) === "B 123"
+show(Sum.mk.B(123)) === "B(123)"
```